### PR TITLE
Fixing permissions on certificate files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,5 @@ INDIGOVR_CERT_DIR: /etc/openvpn/certs
 INDIGOVR_CERT_NAME: "INDIGOVR-{{ INDIGOVR_NODE_TYPE}}-{{ ansible_fqdn }}"
 # CA directory
 INDIGOVR_CA_DIR: /root/CA
+#OpenVPN Unix user
+INDIGOVR_USER: deepvpn

--- a/tasks/centralpoint.yml
+++ b/tasks/centralpoint.yml
@@ -9,10 +9,18 @@
   notify:
     -  Enable and start OpenVPN service
 
+- name: Fix permissions to Diffie-Hellman parameters
+  file:
+    path: "{{ INDIGOVR_CERT_DIR }}/dh2048.pem"
+    group: "{{ INDIGOVR_USER }}"
+    mode: 0644
+
 - name: Copy CRL to OpenVPN
   copy:
     src: "{{ INDIGOVR_CA_DIR }}/crl.pem"
     dest: "{{ INDIGOVR_CERT_DIR }}/crl.pem"
+    group: "{{ INDIGOVR_USER }}"
+    mode: 0644
     remote_src: yes
   notify:
     -  Enable and start OpenVPN service
@@ -21,6 +29,8 @@
   copy:
     src: "{{ INDIGOVR_CA_DIR }}/ca.crt"
     dest: "{{ INDIGOVR_CERT_DIR }}/ca.crt"
+    group: "{{ INDIGOVR_USER }}"
+    mode: 0644
     remote_src: yes
   notify:
     -  Enable and start OpenVPN service
@@ -29,9 +39,9 @@
   file:
     path: /etc/openvpn/ccd
     state: directory
-    mode: 0700
+    mode: 0755
     owner: root
-    group: root
+    group: "{{ INDIGOVR_USER }}"
   notify:
     -  Enable and start OpenVPN service
 
@@ -53,6 +63,8 @@
   copy:
     src: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
     dest: "{{ INDIGOVR_CERT_DIR }}/{{ INDIGOVR_CERT_NAME }}.crt"
+    group: "{{ INDIGOVR_USER }}"
+    mode: 0644
     remote_src: yes
   notify:
     -  Enable and start OpenVPN service

--- a/tasks/openvpn.yml
+++ b/tasks/openvpn.yml
@@ -5,6 +5,11 @@
   notify:
     - Enable and start OpenVPN service
 
+- name: "Create {{ INDIGOVR_USER }} user"
+  user:
+    name: "{{ INDIGOVR_USER }}"
+    state: present
+
 - name: Enable IP forwarding
   sysctl:
     name: net.ipv4.ip_forward
@@ -18,9 +23,9 @@
   file:
     path: /etc/openvpn/certs
     state: directory
-    mode: 0700
+    mode: 0750
     owner: root
-    group: root
+    group: "{{ INDIGOVR_USER }}"
 
 - name: Copy OpenVPN configuration
   template:

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -45,8 +45,12 @@
   copy:
     src: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.crt"
     dest: "{{ INDIGOVR_CERT_DIR }}/{{ INDIGOVR_CERT_NAME }}.crt"
+    group: "{{ INDIGOVR_USER }}"
+    mode: 0644
 
 - name: Copy CA certificate to OpenVPN
   copy:
     src: "/tmp/.indigovr_tmp_ca.crt"
     dest: "{{ INDIGOVR_CERT_DIR }}/ca.crt"
+    group: "{{ INDIGOVR_USER }}"
+    mode: 0644

--- a/tasks/vrouter.yml
+++ b/tasks/vrouter.yml
@@ -4,44 +4,53 @@
 
 - name: Fetch CSR
   fetch:
-    src: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr"
+    src: "{{ INDIGOVR_CERT_DIR }}/{{ INDIGOVR_CERT_NAME }}.csr"
     dest: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.csr"
     flat: yes
+    fail_on_missing: yes
 
 - name: Copy CSR to CA
   copy:
-    src: "/tmp/._indigovr_cp_{{ INDIGOVR_CERT_NAME }}.csr"
+    src: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.csr"
     dest: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr"
   delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
 
 - name: Sign certificate
   shell: openssl ca -config "{{ INDIGOVR_CA_DIR }}/openssl.cnf" -extensions usr_cert -notext -batch -in "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr" -out "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
   args:
     creates: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
   delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
 
 - name: Fetch certificate
   fetch:
     src: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
     dest: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.crt"
     flat: yes
+    fail_on_missing: yes
   delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
 
 - name: Fetch CA certificate
   fetch:
     src: "{{ INDIGOVR_CA_DIR }}/ca.crt"
     dest: "/tmp/.indigovr_tmp_ca.crt"
     flat: yes
+    fail_on_missing: yes
   delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
 
 - name: Copy certificate to OpenVPN
-  fetch:
+  copy:
     src: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.crt"
     dest: "{{ INDIGOVR_CERT_DIR }}/{{ INDIGOVR_CERT_NAME }}.crt"
-    flat: yes
+    group: "{{ INDIGOVR_USER }}"
+    mode: 0644
 
 - name: Copy CA certificate to OpenVPN
-  fetch:
+  copy:
     src: "/tmp/.indigovr_tmp_ca.crt"
     dest: "{{ INDIGOVR_CERT_DIR }}/ca.crt"
-    flat: yes
+    group: "{{ INDIGOVR_USER }}"
+    mode: 0644

--- a/templates/centralpoint.conf.j2
+++ b/templates/centralpoint.conf.j2
@@ -7,8 +7,8 @@ mode server
 persist-key
 persist-tun
 tls-server
-user nobody
-group nogroup
+user {{ INDIGOVR_USER }}
+group {{ INDIGOVR_USER }}
 dev tun
 topology p2p
 proto udp


### PR DESCRIPTION
These commits are fixing issue #5, which was caused by too restrictive permission on crl.pem on centralpoint.

I am not certain why I haven't stumbled upon this on my server, it could have been a different OpenVPN version which have read the file upon startup when it still had root permissions while version on that Ubuntu instance read the file only when needed.

The role now creates its own user, because there is a difference between Debian-like distros and CentOS in nobody's user primary group.

I check all file permissions to reduce the chance of this happening in the future.