### PR TITLE
Fix errors with dirs

### DIFF
--- a/tasks/centralpoint.yml
+++ b/tasks/centralpoint.yml
@@ -48,6 +48,13 @@
 - name: CSR
   include: openssl_csr.yml
 
+- name: Create CA certs dir
+  file:
+    path: "{{ INDIGOVR_CA_DIR }}/certs"
+    state: directory
+    recurse: yes
+  become: true
+
 - name: Copy CSR to CA
   copy:
     src: "{{ INDIGOVR_CERT_DIR }}/{{ INDIGOVR_CERT_NAME }}.csr"

--- a/tasks/vrouter.yml
+++ b/tasks/vrouter.yml
@@ -23,6 +23,14 @@
   delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
   become: true
 
+- name: Create client configuration dir
+  file:
+    path: /etc/openvpn/ccd
+    state: directory
+    recurse: yes
+  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
+
 - name: Create client configuration
   template:
     src: ccd-vrouter.j2


### PR DESCRIPTION
I have detected some issues using the role:

The first one is related with the INDIGOVR_CA_DIR/certs dir as it does not exists (in vrouter and centralpoint nodes):

```
TASK [indigo-dc.indigovr : Copy CSR to CA] *************************************
Monday 01 April 2019  14:23:44.501574
fatal: [192.168.10.12_2 -> 192.168.30.26]: FAILED! => {"changed": false, "checksum": "6c69195a176168c7da27b05377cc0df76f505007", "msg": "Destination directory /root/CA/certs does not exist"}
```

I manually created it and then I get another error in the vrouter node

```
TASK [indigo-dc.indigovr : Create client configuration] ************************
Monday 01 April 2019  15:50:23.614440 
fatal: [192.168.10.4_2 -> 192.168.30.4]: FAILED! => {"changed": false, "checksum": "6b08392bf75b4de9cc976647a51c212fe6a19fb5", "msg": "Destination directory /etc/openvpn/ccd does not exist"}
```

I have added the tasks to create this directories in this PR.