### PR TITLE
Re-use recipes for certificate signing in vrouter and standalone

### DIFF
--- a/tasks/openssl_remote_sign.yml
+++ b/tasks/openssl_remote_sign.yml
@@ -1,0 +1,44 @@
+- name: Fetch CSR
+  fetch:
+    src: "{{ INDIGOVR_CERT_DIR }}/{{ INDIGOVR_CERT_NAME }}.csr"
+    dest: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.csr"
+    flat: yes
+    fail_on_missing: yes
+
+- name: Copy CSR to CA
+  copy:
+    src: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.csr"
+    dest: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr"
+  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
+
+- name: Check certfile stat
+  stat:
+    path: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
+  register: certfile
+  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
+
+- name: Check csr stat
+  stat:
+    path: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr"
+  register: csrfile
+  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
+
+- block:
+  - name: Revoke previous certificate
+    command: openssl ca -config "{{ INDIGOVR_CA_DIR }}/openssl.cnf" -revoke "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
+  - name: Delete previous certificate
+    command: rm -fv "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
+  when: certfile.stat.exists and certfile.stat.mtime < csrfile.stat.mtime
+  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
+
+- name: Sign certificate
+  shell: openssl ca -config "{{ INDIGOVR_CA_DIR }}/openssl.cnf" -extensions usr_cert -notext -batch -in "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr" -out "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
+  args:
+    creates: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
+  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
+  become: true
+

--- a/tasks/standalone.yml
+++ b/tasks/standalone.yml
@@ -2,49 +2,8 @@
 - name: CSR
   include: openssl_csr.yml
 
-- name: Fetch CSR
-  fetch:
-    src: "{{ INDIGOVR_CERT_DIR }}/{{ INDIGOVR_CERT_NAME }}.csr"
-    dest: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.csr"
-    flat: yes
-    fail_on_missing: yes
-
-- name: Copy CSR to CA
-  copy:
-    src: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.csr"
-    dest: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr"
-  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
-  become: true
-
-- name: Check certfile stat
-  stat:
-    path: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
-  register: certfile
-  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
-  become: true
-
-- name: Check csr stat
-  stat:
-    path: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr"
-  register: csrfile
-  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
-  become: true
-
-- block:
-  - name: Revoke previous certificate
-    command: openssl ca -config "{{ INDIGOVR_CA_DIR }}/openssl.cnf" -revoke "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt" 
-  - name: Delete previous certificate
-    command: rm -fv "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
-  when: certfile.stat.exists and certfile.stat.mtime < csrfile.stat.mtime
-  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
-  become: true
-
-- name: Sign certificate
-  shell: openssl ca -config "{{ INDIGOVR_CA_DIR }}/openssl.cnf" -extensions usr_cert -notext -batch -in "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr" -out "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
-  args:
-    creates: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
-  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
-  become: true
+- name: Remote sign
+  include: openssl_remote_sign.yml
 
 - name: Create client configuration
   template:

--- a/tasks/vrouter.yml
+++ b/tasks/vrouter.yml
@@ -2,26 +2,8 @@
 - name: CSR
   include: openssl_csr.yml
 
-- name: Fetch CSR
-  fetch:
-    src: "{{ INDIGOVR_CERT_DIR }}/{{ INDIGOVR_CERT_NAME }}.csr"
-    dest: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.csr"
-    flat: yes
-    fail_on_missing: yes
-
-- name: Copy CSR to CA
-  copy:
-    src: "/tmp/._indigovr_tmp_{{ INDIGOVR_CERT_NAME }}.csr"
-    dest: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr"
-  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
-  become: true
-
-- name: Sign certificate
-  shell: openssl ca -config "{{ INDIGOVR_CA_DIR }}/openssl.cnf" -extensions usr_cert -notext -batch -in "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.csr" -out "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
-  args:
-    creates: "{{ INDIGOVR_CA_DIR }}/certs/{{ INDIGOVR_CERT_NAME }}.crt"
-  delegate_to: "{{ INDIGOVR_CENTRALPOINT_IP }}"
-  become: true
+- name: Remote sign
+  include: openssl_remote_sign.yml
 
 - name: Create client configuration
   template:


### PR DESCRIPTION
Practically this means, the old certificates will be checked and revoked also for vrouters (as is done for standalone already).

This is more like QA thing - I guess the isssue #15 was not related to vrouters.